### PR TITLE
fix(RAIN-47058) update provisioner block to use self object

### DIFF
--- a/terraform/aws/nat-server.tf
+++ b/terraform/aws/nat-server.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "nat" {
       "sudo mkdir -p /etc/openvpn",
       "sudo docker run --name ovpn-data -v /etc/openvpn busybox",
       /* Generate OpenVPN server config */
-      "sudo docker run --volumes-from ovpn-data --rm gosuri/openvpn ovpn_genconfig -p ${var.vpc_cidr} -u udp://${aws_instance.nat.public_ip}"
+      "sudo docker run --volumes-from ovpn-data --rm gosuri/openvpn ovpn_genconfig -p ${var.vpc_cidr} -u udp://${self.public_ip}"
     ]
   }
 }


### PR DESCRIPTION
Signed-off-by: Martin Scott <martin.scott@lacework.net>

See https://lacework.atlassian.net/browse/RAIN-47058

The provisioner parent reference in the block is not allowed

See https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax

Making this change so that `opal` does not detect it as a cycle, this will allow us to scan these repo with opal.

https://lacework.atlassian.net/browse/RAIN-47051 has been raised to improve the error handling in opal for such an issue. 
